### PR TITLE
change bound on k in definition of exactness

### DIFF
--- a/Analytic.tex
+++ b/Analytic.tex
@@ -2006,7 +2006,7 @@ C_c^\bullet: C_c^0\to C_c^1\to\ldots
 \]
 be a complex of complete normed abelian groups, and for $c'>c$, let $\mathrm{res}_{c',c}^i: C_{c'}^\bullet\to C_c^\bullet$ be a map of complexes, satisfying the obvious associativity condition. This datum is admissible if all differentials and maps $\mathrm{res}_{c',c}^i$ are norm-nonincreasing.
 
-For integers $m\geq 0$ and constants $k>0$, $c_0'>0$, the datum $(C_c^\bullet)_c$ is $\leq k$-exact in degrees $\leq m$ and for $c\geq c_0'$ if the following condition is satisfied. For all $c\geq c_0'$ and all $x\in C_{kc}^i$ with $i\leq m$ there is some $y\in C_c^{i-1}$ (which is defined to be $0$ when $i=0$) such that
+For integers $m\geq 0$ and constants $k \ge 1$, $c_0'>0$, the datum $(C_c^\bullet)_c$ is $\leq k$-exact in degrees $\leq m$ and for $c\geq c_0'$ if the following condition is satisfied. For all $c\geq c_0'$ and all $x\in C_{kc}^i$ with $i\leq m$ there is some $y\in C_c^{i-1}$ (which is defined to be $0$ when $i=0$) such that
 \[
 ||\mathrm{res}_{kc,c}^i(x)-d_c^{i-1}(y)||_{C_c^i}\leq k||d_{kc}^i(x)||_{C_{kc}^{i+1}}.
 \]


### PR DESCRIPTION
If k < 1, then there is no restriction C_{kc} -> C_c

(Thanks Kevin Buzzard and Riccardo Brasca.)