### PR TITLE
basic CI to upload PDF as artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Compile TeX
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: Analytic.tex
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Analytic
+          path: ./Analytic.pdf
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./Analytic.pdf


### PR DESCRIPTION
This adds a GitHub actions file which does two things:
- For every commit on every branch in the repo, `Analytic.pdf` is uploaded as an artifact. See e.g. the "Artifacts" button at the top right of [this page](https://github.com/bryangingechen/Analytic/runs/3265647484)
- For every "tagged" commit, `Analytic.pdf` is uploaded as a "GitHub Release" (GitHub releases require a tag). See e.g. [this test release](https://github.com/bryangingechen/Analytic/releases/tag/test)

This is in response to [this Zulip post](https://leanprover.zulipchat.com/#narrow/stream/267928-condensed-mathematics/topic/spaces.20of.20measure.20.2F.20Z.28.28T.29.29_r/near/248653651).